### PR TITLE
Add Room.Tweet()

### DIFF
--- a/campfire/room.go
+++ b/campfire/room.go
@@ -75,3 +75,10 @@ func (self *Room) Sound(name string) {
 
     self.client.Post("/room/"+strconv.Itoa(self.Id)+"/speak", buf)
 }
+
+func (self *Room) Tweet(message string) {
+    msg := &MessageWrapper{Message: &Message{Type: "TweetMessage", Body: message}}
+    buf, _ := json.Marshal(msg)
+
+    self.client.Post("/room/"+strconv.Itoa(self.Id)+"/speak", buf)
+}


### PR DESCRIPTION
This adds `Tweet(string)` as a function to `*campfire.Room` so you can send twitter URLs and have them be formatted properly by campfire.
