### PR TITLE
New slack api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: go
 go:
     - 1.2
+    - 1.4

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ We use Victor as the backbone of our bot, Virbot, within our team Slack chat at 
 
 I currently have adapters written for [Slack](https://slack.com/) and [Campfire](https://campfirenow.com/), however more are to come. Writing an adapter for your favorite service is a good way to contribute to the project :wink:.
 
+*   **Slack**
+    To use victor with Slack, you need to configure two slack integrations first: An **[incoming webhook integration](https://my.slack.com/services/new/incoming-webhook)** and an **[outgoing webhook integration](https://my.slack.com/services/new/outgoing-webhook)**. The *incoming* webhook integration gives you an URI which is used by victor to post messages into your slack channel. Pass this URI to victor via the environment variable `SLACK_INCOMING_WEBHOOK_URI`. In the *outgoing* webhook integration, you configure an URI that Slack uses to notify victor about Slack messages. The *path* of the configured URI needs to be set in the environment variable `SLACK_OUTGOING_WEBHOOK`.
+    
+        $ SLACK_INCOMING_WEBHOOK_URI=https://hooks.slack.com/services/REPLACE/THIS \
+            SLACK_OUTGOING_WEBHOOK=/your-hook-path \
+            ./your-chat-bot
+    
+    Another setting you can make is that will be displayed next to your bot's name in Slack. Pass the environment variable `SLACK_EMOJI` with your favorite emoji (in [colon syntax](http://www.emoji-cheat-sheet.com/)) to victor. 
+
 ### Making Him Your Own
 
 Victor is more of a framework for constructing your own bot so he doesn't do a whole lot out-of-the-box. I'll be adding more default behavior to him as time progresses. You can use the programs located in `examples/` as starting points to create your own executable.

--- a/pkg/chat/slack/slack.go
+++ b/pkg/chat/slack/slack.go
@@ -2,40 +2,41 @@ package slack
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/brettbuddin/victor/pkg/chat"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/brettbuddin/victor/pkg/chat"
 )
 
 func init() {
 	chat.Register("slack", func(r chat.Robot) chat.Adapter {
-		team := os.Getenv("VICTOR_SLACK_TEAM")
-		token := os.Getenv("VICTOR_SLACK_TOKEN")
+		slackOutgoingWebhookPath := os.Getenv("SLACK_OUTGOING_WEBHOOK")
+		slackIncomingWebhookUri := os.Getenv("SLACK_INCOMING_WEBHOOK_URI")
 
-		if team == "" || token == "" {
-			log.Println("The following environment variables are required:")
-			log.Println("VICTOR_SLACK_TEAM, VICTOR_SLACK_TOKEN")
+		if slackOutgoingWebhookPath == "" || slackIncomingWebhookUri == "" {
+			log.Println("The following environment variable is required:")
+			log.Println("SLACK_INCOMING_WEBHOOK_URI, SLACK_OUTGOING_WEBHOOK")
 			os.Exit(1)
 		}
 
 		return &slack{
-			robot: r,
-			team:  team,
-			token: token,
+			robot:               r,
+			outgoingWebhookPath: slackOutgoingWebhookPath,
+			incomingWebhookUri:  slackIncomingWebhookUri,
 		}
 	})
 }
 
 type slack struct {
-	robot       chat.Robot
-	team, token string
+	robot               chat.Robot
+	incomingWebhookUri  string
+	outgoingWebhookPath string
 }
 
 func (s *slack) Run() {
-	s.robot.HTTP().HandleFunc("/hubot/slack-webhook", func(w http.ResponseWriter, r *http.Request) {
+	s.robot.HTTP().HandleFunc(s.outgoingWebhookPath, func(w http.ResponseWriter, r *http.Request) {
 		s.robot.Receive(&message{
 			userID:      r.PostFormValue("user_id"),
 			userName:    r.PostFormValue("user_name"),
@@ -57,8 +58,11 @@ func (s *slack) Send(channelID, msg string) {
 		log.Println("error sending to chat:", err)
 	}
 
-	endpoint := fmt.Sprintf("https://%s.slack.com/services/hooks/incoming-webhook?token=%s", s.team, s.token)
-	http.PostForm(endpoint, url.Values{"payload": {string(body)}})
+	if resp, err := HttpClient.PostForm(s.incomingWebhookUri, url.Values{"payload": {string(body)}}); err != nil {
+		log.Printf("Slack API call failed: %s", err)
+	} else if resp.StatusCode != 200 {
+		log.Printf("Slack API returned HTTP status code %d", resp.StatusCode)
+	}
 }
 
 func (s *slack) Stop() {

--- a/pkg/chat/slack/slack.go
+++ b/pkg/chat/slack/slack.go
@@ -31,6 +31,8 @@ func init() {
 	})
 }
 
+var HttpClient *http.Client
+
 type slack struct {
 	robot               chat.Robot
 	incomingWebhookUri  string
@@ -39,6 +41,10 @@ type slack struct {
 }
 
 func (s *slack) Run() {
+	if nil == HttpClient {
+		HttpClient = http.DefaultClient
+	}
+
 	s.robot.HTTP().HandleFunc(s.outgoingWebhookPath, func(w http.ResponseWriter, r *http.Request) {
 		s.robot.Receive(&message{
 			userID:      r.PostFormValue("user_id"),

--- a/pkg/chat/slack/slack.go
+++ b/pkg/chat/slack/slack.go
@@ -14,6 +14,7 @@ func init() {
 	chat.Register("slack", func(r chat.Robot) chat.Adapter {
 		slackOutgoingWebhookPath := os.Getenv("SLACK_OUTGOING_WEBHOOK")
 		slackIncomingWebhookUri := os.Getenv("SLACK_INCOMING_WEBHOOK_URI")
+		emoji := os.Getenv("SLACK_EMOJI")
 
 		if slackOutgoingWebhookPath == "" || slackIncomingWebhookUri == "" {
 			log.Println("The following environment variable is required:")
@@ -25,6 +26,7 @@ func init() {
 			robot:               r,
 			outgoingWebhookPath: slackOutgoingWebhookPath,
 			incomingWebhookUri:  slackIncomingWebhookUri,
+			emoji:               emoji,
 		}
 	})
 }
@@ -33,6 +35,7 @@ type slack struct {
 	robot               chat.Robot
 	incomingWebhookUri  string
 	outgoingWebhookPath string
+	emoji               string
 }
 
 func (s *slack) Run() {
@@ -52,6 +55,7 @@ func (s *slack) Send(channelID, msg string) {
 		Channel:  channelID,
 		Username: s.robot.Name(),
 		Text:     msg,
+		Emoji:    s.emoji,
 	})
 
 	if err != nil {
@@ -72,6 +76,7 @@ type outgoingMessage struct {
 	Channel  string `json:"channel"`
 	Username string `json:"username"`
 	Text     string `json:"text"`
+	Emoji    string `json:"icon_emoji,omitempty"`
 }
 
 type message struct {


### PR DESCRIPTION
Slack updated it's incoming/outgoing webhook API. This PR adapts victor to this change. Also, it enables users to specify a custom Slack Icon for the Bot and to configure the HTTP client used to talk to the Slack API.