### PR TITLE
Slack Realtime API + General Improvements

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -1,20 +1,39 @@
 package victor
 
 import (
-	"github.com/brettbuddin/victor/pkg/chat"
 	"regexp"
 	"strings"
+
+	"github.com/brettbuddin/victor/pkg/chat"
 )
+
+type HandlerPair interface {
+	Exp() *regexp.Regexp
+	Handler() Handler
+}
+
+type handlerPair struct {
+	exp    *regexp.Regexp
+	handle Handler
+}
+
+func (pair *handlerPair) Exp() *regexp.Regexp {
+	return pair.exp
+}
+
+func (pair *handlerPair) Handler() Handler {
+	return pair.handle
+}
 
 type dispatch struct {
 	robot    Robot
-	handlers map[*regexp.Regexp]Handler
+	handlers []HandlerPair
 }
 
 func newDispatch(bot Robot) *dispatch {
 	return &dispatch{
 		robot:    bot,
-		handlers: make(map[*regexp.Regexp]Handler),
+		handlers: make([]HandlerPair, 0, 10),
 	}
 }
 
@@ -39,7 +58,10 @@ func (d *dispatch) HandleFunc(exp string, f HandlerFunc) {
 }
 
 func (d *dispatch) handle(exp string, h Handler) {
-	d.handlers[regexp.MustCompile(exp)] = h
+	d.handlers = append(d.handlers, &handlerPair{
+		exp:    regexp.MustCompile(exp),
+		handle: h,
+	})
 }
 
 // Direct wraps a regexp pattern in the necessary pattern
@@ -56,12 +78,12 @@ func (d *dispatch) Direct(exp string) string {
 
 // ProcessMessage finds a match for a message and runs its Handler
 func (d *dispatch) ProcessMessage(m chat.Message) {
-	for exp, handler := range d.handlers {
-		matches := exp.FindAllStringSubmatch(m.Text(), -1)
+	for _, pair := range d.handlers {
+		matches := pair.Exp().FindAllStringSubmatch(m.Text(), -1)
 
 		if len(matches) > 0 {
 			params := matches[0][1:]
-			handler.Handle(&state{
+			pair.Handler().Handle(&state{
 				robot:   d.robot,
 				message: m,
 				params:  params,

--- a/dispatch.go
+++ b/dispatch.go
@@ -7,6 +7,9 @@ import (
 	"github.com/brettbuddin/victor/pkg/chat"
 )
 
+// HandlerPair provides an interface for a handler as well as the regular
+// expression which a message should match in order to pass control onto the
+// handler
 type HandlerPair interface {
 	Exp() *regexp.Regexp
 	Handler() Handler

--- a/examples/functions/defaults.go
+++ b/examples/functions/defaults.go
@@ -1,4 +1,4 @@
-package victor
+package functions
 
 import (
 	"fmt"

--- a/examples/functions/defaults.go
+++ b/examples/functions/defaults.go
@@ -5,14 +5,16 @@ import (
 	"math/rand"
 	"strconv"
 	"time"
+
+	"github.com/brettbuddin/victor"
 )
 
-func defaults(robot Robot) {
-	robot.HandleFunc(robot.Direct("ping"), func(s State) {
+func Defaults(robot victor.Robot) {
+	robot.HandleFunc(robot.Direct("ping"), func(s victor.State) {
 		s.Chat().Send(s.Message().ChannelID(), "pong!")
 	})
 
-	robot.HandleFunc(robot.Direct("roll(\\s(\\d+))?"), func(s State) {
+	robot.HandleFunc(robot.Direct("roll(\\s(\\d+))?"), func(s victor.State) {
 		defer recover()
 
 		bound := 100

--- a/handler.go
+++ b/handler.go
@@ -4,16 +4,22 @@ import (
 	"github.com/brettbuddin/victor/pkg/chat"
 )
 
+// Handler defines an interface for a message handler
 type Handler interface {
 	Handle(State)
 }
 
+// HandlerFunc defines the parameters for a handler's function
 type HandlerFunc func(State)
 
+// Handle calls the handler's response function which replies to a message
+// appropriately.
 func (f HandlerFunc) Handle(s State) {
 	f(s)
 }
 
+// State defines an interface to provide a handler all of the necessary
+// information to reply to a message
 type State interface {
 	Robot() Robot
 	Chat() chat.Adapter

--- a/pkg/chat/adapter.go
+++ b/pkg/chat/adapter.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"fmt"
+
 	"github.com/brettbuddin/victor/pkg/store"
 	"github.com/gorilla/mux"
 )
@@ -36,6 +37,7 @@ type Robot interface {
 	Store() store.Adapter
 	Chat() Adapter
 	Receive(Message)
+	Config() (interface{}, bool)
 }
 
 type Message interface {

--- a/pkg/chat/adapter.go
+++ b/pkg/chat/adapter.go
@@ -37,7 +37,7 @@ type Robot interface {
 	Store() store.Adapter
 	Chat() Adapter
 	Receive(Message)
-	Config() (interface{}, bool)
+	AdapterConfig() (interface{}, bool)
 }
 
 type Message interface {

--- a/pkg/chat/slackRealtime/slackRealtime.go
+++ b/pkg/chat/slackRealtime/slackRealtime.go
@@ -1,0 +1,227 @@
+package slackRealtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/brettbuddin/victor/pkg/chat"
+	"github.com/nlopes/slack"
+)
+
+// The Slack Websocket's registered adapter name for the victor framework.
+const AdapterName = "slackRealtime"
+
+// Prefix for the user's ID which is used when reading/writing from the bot's store
+const userInfoPrefix = AdapterName + "."
+
+// init registers SlackAdapter to the victor chat framework.
+func init() {
+	chat.Register(AdapterName, func(r chat.Robot) chat.Adapter {
+		config, configSet := r.AdapterConfig()
+		if !configSet {
+			log.Println("A configuration struct implementing the SlackConfig interface must be set.")
+			os.Exit(1)
+		}
+		sConfig, ok := config.(SlackConfig)
+		if !ok {
+			log.Println("The bot's config must implement the SlackConfig interface.")
+			os.Exit(1)
+		}
+		return &SlackAdapter{
+			robot:      r,
+			chSender:   make(chan *slack.OutgoingMessage),
+			chReceiver: make(chan slack.SlackEvent),
+			token:      sConfig.Token(),
+		}
+	})
+}
+
+// Config provides the slack adapter with the necessary information to open a
+// websocket connection with the slack Real time API.
+type SlackConfig interface {
+	Token() string
+}
+
+type Config struct {
+	token string
+}
+
+func NewConfig(token string) Config {
+	return Config{token: token}
+}
+
+func (c Config) Token() string {
+	return c.token
+}
+
+// SlackAdapter holds all information needed by the adapter to send/receive messages.
+type SlackAdapter struct {
+	robot      chat.Robot
+	token      string
+	instance   *slack.Slack
+	wsAPI      *slack.SlackWS
+	chSender   chan *slack.OutgoingMessage
+	chReceiver chan slack.SlackEvent
+}
+
+// Run starts the adapter and begins to listen for new messages to send/receive.
+// At the moment this will crash the program and print the error messages to a
+// log if the connection fails.
+func (adapter *SlackAdapter) Run() {
+	adapter.instance = slack.New(adapter.token)
+	adapter.instance.SetDebug(false)
+	// TODO need to look up what these values actually mean
+	var err error
+	adapter.wsAPI, err = adapter.instance.StartRTM("", "http://example.com")
+	if err != nil {
+		log.Println(err.Error())
+		os.Exit(1)
+	}
+	// sets up the monitoring code for sending/receiving messages from slack
+	go adapter.wsAPI.HandleIncomingEvents(adapter.chReceiver)
+	go adapter.wsAPI.Keepalive(20 * time.Second)
+	go adapter.sendMessages()
+	adapter.monitorEvents()
+
+}
+
+// Stop stops the adapter.
+// TODO implement
+func (adapter *SlackAdapter) Stop() {
+}
+
+func (adapter *SlackAdapter) sendMessages() {
+	for {
+		msg, ok := <-adapter.chSender
+		if !ok {
+			break
+		}
+		adapter.wsAPI.SendMessage(msg)
+	}
+}
+
+func (adapter *SlackAdapter) getUser(userID string) (*slack.User, error) {
+	// try to get the stored user info
+	userStr, exists := adapter.getStoreKey(userID)
+	// if it hasn't been stored then perform a slack API call to get it and
+	// store it
+	if !exists {
+		user, err := adapter.instance.GetUserInfo(userID)
+		if err != nil {
+			log.Println(err.Error())
+			return nil, err
+		}
+		// try to encode it as a json string for storage
+		var userArr []byte
+		if userArr, err = json.Marshal(user); err == nil {
+			adapter.setStoreKey(userID, string(userArr))
+		}
+		return user, nil
+	}
+	var user slack.User
+	// convert the json string to the user object
+	err := json.Unmarshal([]byte(userStr), &user)
+	if err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+	return &user, nil
+
+	// TODO handle an error on the unmarshalling of the stored json object?
+}
+
+func (adapter *SlackAdapter) handleMessage(event *slack.MessageEvent) {
+	user, _ := adapter.getUser(event.UserId)
+	// TODO use error
+	if user != nil {
+		// ignore any messages that are sent by us
+		if user.Id == adapter.instance.GetInfo().User.Id {
+			return
+		}
+		msg := slackMessage{
+			user:      user,
+			text:      adapter.unescapeMessage(event.Text),
+			channelID: event.ChannelId,
+			// TODO change or not needed?
+			channelName: event.ChannelId,
+		}
+		adapter.robot.Receive(&msg)
+		log.Println(msg.Text())
+	}
+}
+
+// Replace all instances of the bot's encoded name with it's actual name.
+//
+// TODO might want to update this to replace all matches of <@USER_ID> with
+// the user's name.
+func (adapter *SlackAdapter) unescapeMessage(msg string) string {
+	userID := adapter.instance.GetInfo().User.Id
+	return strings.Replace(msg, getEncodedUserID(userID), adapter.robot.Name(), -1)
+}
+
+// Returns the encoded string version of a user's slack ID.
+func getEncodedUserID(userID string) string {
+	return fmt.Sprintf("<@%s>", userID)
+}
+
+func (adapter *SlackAdapter) monitorEvents() {
+	for {
+		msg := <-adapter.chReceiver
+		switch msg.Data.(type) {
+		case *slack.MessageEvent:
+			go adapter.handleMessage(msg.Data.(*slack.MessageEvent))
+		}
+	}
+}
+
+// Send sends a message to the given slack channel.
+func (adapter *SlackAdapter) Send(channelID, msg string) {
+	adapter.chSender <- adapter.wsAPI.NewOutgoingMessage(msg, channelID)
+}
+
+func (adapter *SlackAdapter) getStoreKey(key string) (string, bool) {
+	return adapter.robot.Store().Get(userInfoPrefix + key)
+}
+
+func (adapter *SlackAdapter) setStoreKey(key, val string) {
+	adapter.robot.Store().Set(userInfoPrefix+key, val)
+}
+
+type slackMessage struct {
+	user        *slack.User
+	text        string
+	channelID   string
+	channelName string
+}
+
+func (m *slackMessage) User() *slack.User {
+	return m.user
+}
+
+func (m *slackMessage) UserID() string {
+	return m.user.Id
+}
+
+func (m *slackMessage) UserName() string {
+	return m.user.Name
+}
+
+func (m *slackMessage) EmailAddress() string {
+	return m.user.Profile.Email
+}
+
+func (m *slackMessage) ChannelID() string {
+	return m.channelID
+}
+
+func (m *slackMessage) ChannelName() string {
+	return m.channelName
+}
+
+func (m *slackMessage) Text() string {
+	return m.text
+}

--- a/pkg/store/adapter.go
+++ b/pkg/store/adapter.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"fmt"
+
+	"github.com/gorilla/mux"
 )
 
 var adapters = map[string]InitFunc{}
@@ -20,7 +22,13 @@ func Load(name string) (InitFunc, error) {
 	return a, nil
 }
 
-type InitFunc func() Adapter
+type InitFunc func(Robot) Adapter
+
+type Robot interface {
+	Name() string
+	HTTP() *mux.Router
+	StoreConfig() (interface{}, bool)
+}
 
 type Adapter interface {
 	Get(string) (string, bool)

--- a/pkg/store/boltstore/boltstore.go
+++ b/pkg/store/boltstore/boltstore.go
@@ -1,4 +1,4 @@
-package store
+package boltstore
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/boltdb/bolt"
+	"github.com/brettbuddin/victor/pkg/store"
 )
 
 var _ = fmt.Println
@@ -16,7 +17,7 @@ const (
 
 func init() {
 	// type InitFunc func() Adapter
-	Register("bolt", func() Adapter {
+	store.Register("bolt", func(r store.Robot) store.Adapter {
 		return newBoltStore()
 	})
 }

--- a/pkg/store/boltstore/boltstore_test.go
+++ b/pkg/store/boltstore/boltstore_test.go
@@ -1,4 +1,4 @@
-package store
+package boltstore
 
 import (
 	"os"

--- a/pkg/store/memory/memorystore.go
+++ b/pkg/store/memory/memorystore.go
@@ -1,11 +1,13 @@
-package store
+package memory
 
 import (
 	"sync"
+
+	"github.com/brettbuddin/victor/pkg/store"
 )
 
 func init() {
-	Register("memory", func() Adapter {
+	store.Register("memory", func(r store.Robot) store.Adapter {
 		return &MemoryStore{
 			data: make(map[string]string),
 		}

--- a/robot.go
+++ b/robot.go
@@ -140,7 +140,9 @@ func (r *robot) Run() {
 func (r *robot) Stop() {
 	r.chat.Stop()
 	close(r.stop)
-	r.http.Stop()
+	if r.http != nil {
+		r.http.Stop()
+	}
 }
 
 // Name returns the name of the bot

--- a/robot.go
+++ b/robot.go
@@ -104,8 +104,6 @@ func New(config Config) *robot {
 	bot.adapterConfig = config.AdapterConfig
 	bot.dispatch = newDispatch(bot)
 	bot.chat = chatInitFunc(bot)
-
-	defaults(bot)
 	return bot
 }
 

--- a/robot.go
+++ b/robot.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/brettbuddin/victor/pkg/chat"
+	// Blank import used init adapters which registers them with victor
 	_ "github.com/brettbuddin/victor/pkg/chat/campfire"
 	_ "github.com/brettbuddin/victor/pkg/chat/hipchat"
 	_ "github.com/brettbuddin/victor/pkg/chat/shell"
@@ -14,11 +15,13 @@ import (
 	_ "github.com/brettbuddin/victor/pkg/chat/slackRealtime"
 	"github.com/brettbuddin/victor/pkg/httpserver"
 	"github.com/brettbuddin/victor/pkg/store"
+	// Blank import used init adapters which registers them with victor
 	_ "github.com/brettbuddin/victor/pkg/store/boltstore"
 	_ "github.com/brettbuddin/victor/pkg/store/memory"
 	"github.com/gorilla/mux"
 )
 
+// Robot provides an interface for a victor chat robot.
 type Robot interface {
 	Run()
 	Stop()
@@ -34,6 +37,9 @@ type Robot interface {
 	StoreConfig() (interface{}, bool)
 }
 
+// Config provides all of the configuration parameters needed in order to
+// initialize a robot. It also allows for optional configuration structs for
+// both the chat and storage adapters which they may or may not require.
 type Config struct {
 	Name,
 	ChatAdapter,

--- a/robot.go
+++ b/robot.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/brettbuddin/victor/pkg/chat/hipchat"
 	_ "github.com/brettbuddin/victor/pkg/chat/shell"
 	_ "github.com/brettbuddin/victor/pkg/chat/slack"
+	_ "github.com/brettbuddin/victor/pkg/chat/slackRealtime"
 	"github.com/brettbuddin/victor/pkg/httpserver"
 	"github.com/brettbuddin/victor/pkg/store"
 	_ "github.com/brettbuddin/victor/pkg/store/boltstore"


### PR DESCRIPTION
Implemented a new slack adapter for [Slack's Realtime Messaging API](https://api.slack.com/rtm) using https://github.com/nlopes/slack as the underlying slack API.

Allow for non-environment variable configuration parameters for chat/store adapters which are fully optional and don't break existing adapters or examples.

I also changed dispatch to use an slice so that the iteration order while matching regular expressions in ProcessMessage matches the order that the handlers were added. In particular, this helps when writing a "default" handler which could match anything after the bot name and reply with an "Unsupported operation" message and does not affect ProcessMessage's efficiency.

The only major change I have made is that the http server and router are optional in that they are not initialized until the HTTP getter method is called. This should allow previous adapters to work without change and future adapters (such as the new slack adapter) to forgo the unneeded http listener which also allowed full access to the bot's store. It should also allow for multiple bot's to be created without worrying about setting unique http ports assuming that their adapters do not require the provided HTTP server/router.